### PR TITLE
feat: Add ability to delete single track from history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ antra-wails/frontend/dist/
 antra-wails/frontend/node_modules/
 antra-wails/frontend/package.json.md5
 antra-wails/*.exe
+antra-wails/_pyinstaller_work/
 
 # Music library (user data - not part of the repo)
 Music/

--- a/antra-wails/app_backend.go
+++ b/antra-wails/app_backend.go
@@ -35,6 +35,13 @@ type Config struct {
 	FilenameFormat        string   `json:"filename_format,omitempty"`
 }
 
+type HistoryTrack struct {
+	Title    string `json:"title"`
+	Artist   string `json:"artist"`
+	FilePath string `json:"file_path,omitempty"`
+	Status   string `json:"status"`
+}
+
 type HistoryItem struct {
 	Date       string         `json:"date"`
 	URL        string         `json:"url"`
@@ -46,6 +53,7 @@ type HistoryItem struct {
 	Skipped    int            `json:"skipped"`
 	Error      string         `json:"error,omitempty"`
 	Sources    map[string]int `json:"sources"`
+	Tracks     []HistoryTrack `json:"tracks,omitempty"`
 }
 
 func getAppDataDir() string {
@@ -158,6 +166,47 @@ func (a *App) ClearHistory() error {
 	if _, err := os.Stat(path); err == nil {
 		return os.Remove(path)
 	}
+	return nil
+}
+
+// ForgetTrack removes a track's download state and deletes its file so it can be re-downloaded.
+func (a *App) ForgetTrack(filePath string) error {
+	cfg := a.GetConfig()
+	statePath := filepath.Join(cfg.DownloadPath, ".antra_state.json")
+
+	data, err := os.ReadFile(statePath)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	if len(data) > 0 {
+		var state map[string]interface{}
+		if err := json.Unmarshal(data, &state); err != nil {
+			return err
+		}
+
+		cleanTarget := filepath.Clean(filePath)
+		for key, val := range state {
+			if strings.HasPrefix(key, "TRACK:") {
+				if valStr, ok := val.(string); ok && filepath.Clean(valStr) == cleanTarget {
+					delete(state, key)
+				}
+			}
+		}
+
+		updated, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(statePath, updated, 0644); err != nil {
+			return err
+		}
+	}
+
+	if _, err := os.Stat(filePath); err == nil {
+		os.Remove(filePath)
+	}
+
 	return nil
 }
 

--- a/antra-wails/frontend/src/App.svelte
+++ b/antra-wails/frontend/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { GetConfig, SaveConfig, PickDirectory, StartDownload, CancelDownload, GetHistory, AddHistory, ClearHistory } from '../wailsjs/go/main/App.js';
+  import { GetConfig, SaveConfig, PickDirectory, StartDownload, CancelDownload, GetHistory, AddHistory, ClearHistory, ForgetTrack } from '../wailsjs/go/main/App.js';
   import { ScanFolder, AnalyzeAudio, PickAnalyzerFiles, WriteFile, GetArtistDiscography, SearchArtists, CheckSourceHealth, GetSlskdWebUIInfo } from '../wailsjs/go/main/App.js';
   import { EventsOn, BrowserOpenURL } from '../wailsjs/runtime/runtime.js';
   import type { main } from '../wailsjs/go/models';
@@ -47,6 +47,8 @@
   let showSettings = false;
   let slskdWebUIInfo: {url: string, username: string, password: string} | null = null;
   let historyItems: any[] = [];
+  let expandedHistoryItems: Set<number> = new Set();
+  let forgottenTracks: Set<string> = new Set();
   let inputUrl = '';
   let isDownloading = false;
 
@@ -868,6 +870,8 @@
       console.error(e);
       historyItems = [];
     }
+    expandedHistoryItems = new Set();
+    forgottenTracks = new Set();
     showHistory = true;
   }
 
@@ -876,6 +880,26 @@
       await ClearHistory();
       historyItems = [];
     }
+  }
+
+  async function forgetTrack(itemIndex: number, trackIndex: number, filePath: string) {
+    const key = `${itemIndex}-${trackIndex}`;
+    try {
+      await ForgetTrack(filePath);
+      forgottenTracks = new Set([...forgottenTracks, key]);
+    } catch (err) {
+      console.error('Failed to forget track:', err);
+    }
+  }
+
+  function toggleHistoryExpand(index: number) {
+    const next = new Set(expandedHistoryItems);
+    if (next.has(index)) {
+      next.delete(index);
+    } else {
+      next.add(index);
+    }
+    expandedHistoryItems = next;
   }
 
   async function saveSettings() {
@@ -1242,7 +1266,7 @@
       {#if historyItems.length === 0}
         <p style="color: #777; font-size: 13px; text-align: center;">No history found.</p>
       {:else}
-        {#each historyItems as item}
+        {#each historyItems as item, i}
           <div class="history-card" style={item.error ? 'border-color: rgba(248,113,113,0.4); background: rgba(248,113,113,0.04);' : ''}>
             <div style="display: flex; align-items: flex-start; gap: 10px;">
               {#if item.artwork_url}
@@ -1279,6 +1303,39 @@
                 {#each Object.entries(item.sources) as [src, count]}
                   <span style="background: rgba(0,255,204,0.1); padding: 2px 6px; border-radius: 4px; border: 1px solid rgba(0,255,204,0.2)">{src}: {count}</span>
                 {/each}
+              </div>
+            {/if}
+            {#if item.tracks && item.tracks.length > 0}
+              <div style="margin-top: 8px;">
+                <button
+                  on:click={() => toggleHistoryExpand(i)}
+                  style="font-size: 11px; padding: 2px 8px; border-color: rgba(255,255,255,0.15); color: rgba(255,255,255,0.5); background: transparent;"
+                >{expandedHistoryItems.has(i) ? '▾' : '▸'} {item.tracks.length} tracks</button>
+                {#if expandedHistoryItems.has(i)}
+                  <div style="margin-top: 6px; display: flex; flex-direction: column; gap: 3px; max-height: 200px; overflow-y: auto;">
+                    {#each item.tracks as track, ti}
+                      {#if !forgottenTracks.has(`${i}-${ti}`)}
+                        <div style="display: flex; align-items: center; gap: 6px; padding: 3px 6px; border-radius: 4px; background: rgba(255,255,255,0.03);">
+                          <span style="flex: 1; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; opacity: 0.75;">{track.title} <span style="opacity:0.5;">— {track.artist}</span></span>
+                          {#if track.status === 'COMPLETED'}
+                            <span style="font-size: 10px; color: #4ade80; background: rgba(74,222,128,0.08); border: 1px solid rgba(74,222,128,0.2); border-radius: 3px; padding: 1px 5px; flex-shrink:0;">✓</span>
+                          {:else if track.status === 'SKIPPED'}
+                            <span style="font-size: 10px; color: #94a3b8; background: rgba(148,163,184,0.08); border: 1px solid rgba(148,163,184,0.2); border-radius: 3px; padding: 1px 5px; flex-shrink:0;">skipped</span>
+                          {:else if track.status === 'FAILED'}
+                            <span style="font-size: 10px; color: #f87171; background: rgba(248,113,113,0.08); border: 1px solid rgba(248,113,113,0.2); border-radius: 3px; padding: 1px 5px; flex-shrink:0;">failed</span>
+                          {/if}
+                          {#if track.file_path && (track.status === 'COMPLETED' || track.status === 'SKIPPED')}
+                            <button
+                              title="Delete from library so this track can be re-downloaded"
+                              on:click={() => forgetTrack(i, ti, track.file_path)}
+                              style="flex-shrink: 0; padding: 1px 7px; font-size: 10px; border-color: rgba(248,113,113,0.3); color: #f87171; background: rgba(248,113,113,0.05);"
+                            >Delete</button>
+                          {/if}
+                        </div>
+                      {/if}
+                    {/each}
+                  </div>
+                {/if}
               </div>
             {/if}
           </div>

--- a/antra-wails/frontend/src/App.svelte
+++ b/antra-wails/frontend/src/App.svelte
@@ -47,7 +47,6 @@
   let showSettings = false;
   let slskdWebUIInfo: {url: string, username: string, password: string} | null = null;
   let historyItems: any[] = [];
-  let expandedHistoryItems: Set<number> = new Set();
   let forgottenTracks: Set<string> = new Set();
   let inputUrl = '';
   let isDownloading = false;
@@ -870,7 +869,6 @@
       console.error(e);
       historyItems = [];
     }
-    expandedHistoryItems = new Set();
     forgottenTracks = new Set();
     showHistory = true;
   }
@@ -892,15 +890,6 @@
     }
   }
 
-  function toggleHistoryExpand(index: number) {
-    const next = new Set(expandedHistoryItems);
-    if (next.has(index)) {
-      next.delete(index);
-    } else {
-      next.add(index);
-    }
-    expandedHistoryItems = next;
-  }
 
   async function saveSettings() {
     await SaveConfig(config);
@@ -1306,36 +1295,28 @@
               </div>
             {/if}
             {#if item.tracks && item.tracks.length > 0}
-              <div style="margin-top: 8px;">
-                <button
-                  on:click={() => toggleHistoryExpand(i)}
-                  style="font-size: 11px; padding: 2px 8px; border-color: rgba(255,255,255,0.15); color: rgba(255,255,255,0.5); background: transparent;"
-                >{expandedHistoryItems.has(i) ? '▾' : '▸'} {item.tracks.length} tracks</button>
-                {#if expandedHistoryItems.has(i)}
-                  <div style="margin-top: 6px; display: flex; flex-direction: column; gap: 3px; max-height: 200px; overflow-y: auto;">
-                    {#each item.tracks as track, ti}
-                      {#if !forgottenTracks.has(`${i}-${ti}`)}
-                        <div style="display: flex; align-items: center; gap: 6px; padding: 3px 6px; border-radius: 4px; background: rgba(255,255,255,0.03);">
-                          <span style="flex: 1; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; opacity: 0.75;">{track.title} <span style="opacity:0.5;">— {track.artist}</span></span>
-                          {#if track.status === 'COMPLETED'}
-                            <span style="font-size: 10px; color: #4ade80; background: rgba(74,222,128,0.08); border: 1px solid rgba(74,222,128,0.2); border-radius: 3px; padding: 1px 5px; flex-shrink:0;">✓</span>
-                          {:else if track.status === 'SKIPPED'}
-                            <span style="font-size: 10px; color: #94a3b8; background: rgba(148,163,184,0.08); border: 1px solid rgba(148,163,184,0.2); border-radius: 3px; padding: 1px 5px; flex-shrink:0;">skipped</span>
-                          {:else if track.status === 'FAILED'}
-                            <span style="font-size: 10px; color: #f87171; background: rgba(248,113,113,0.08); border: 1px solid rgba(248,113,113,0.2); border-radius: 3px; padding: 1px 5px; flex-shrink:0;">failed</span>
-                          {/if}
-                          {#if track.file_path && (track.status === 'COMPLETED' || track.status === 'SKIPPED')}
-                            <button
-                              title="Delete from library so this track can be re-downloaded"
-                              on:click={() => forgetTrack(i, ti, track.file_path)}
-                              style="flex-shrink: 0; padding: 1px 7px; font-size: 10px; border-color: rgba(248,113,113,0.3); color: #f87171; background: rgba(248,113,113,0.05);"
-                            >Delete</button>
-                          {/if}
-                        </div>
+              <div style="margin-top: 8px; display: flex; flex-direction: column; gap: 3px; max-height: 200px; overflow-y: auto;">
+                {#each item.tracks as track, ti}
+                  {#if !forgottenTracks.has(`${i}-${ti}`)}
+                    <div style="display: flex; align-items: center; gap: 6px; padding: 3px 6px; border-radius: 4px; background: rgba(255,255,255,0.03);">
+                      <span style="flex: 1; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; opacity: 0.75;">{track.title} <span style="opacity:0.5;">— {track.artist}</span></span>
+                      {#if track.status === 'COMPLETED'}
+                        <span style="font-size: 10px; color: #4ade80; background: rgba(74,222,128,0.08); border: 1px solid rgba(74,222,128,0.2); border-radius: 3px; padding: 1px 5px; flex-shrink:0;">✓</span>
+                      {:else if track.status === 'SKIPPED'}
+                        <span style="font-size: 10px; color: #94a3b8; background: rgba(148,163,184,0.08); border: 1px solid rgba(148,163,184,0.2); border-radius: 3px; padding: 1px 5px; flex-shrink:0;">skipped</span>
+                      {:else if track.status === 'FAILED'}
+                        <span style="font-size: 10px; color: #f87171; background: rgba(248,113,113,0.08); border: 1px solid rgba(248,113,113,0.2); border-radius: 3px; padding: 1px 5px; flex-shrink:0;">failed</span>
                       {/if}
-                    {/each}
-                  </div>
-                {/if}
+                      {#if track.file_path && (track.status === 'COMPLETED' || track.status === 'SKIPPED')}
+                        <button
+                          title="Delete from library so this track can be re-downloaded"
+                          on:click={() => forgetTrack(i, ti, track.file_path)}
+                          style="flex-shrink: 0; padding: 1px 7px; font-size: 10px; border-color: rgba(248,113,113,0.3); color: #f87171; background: rgba(248,113,113,0.05);"
+                        >Delete</button>
+                      {/if}
+                    </div>
+                  {/if}
+                {/each}
               </div>
             {/if}
           </div>

--- a/antra-wails/frontend/wailsjs/go/main/App.d.ts
+++ b/antra-wails/frontend/wailsjs/go/main/App.d.ts
@@ -44,4 +44,6 @@ export function SetSpotifyToken(arg1:string):Promise<string>;
 
 export function StartDownload(arg1:Array<string>):Promise<void>;
 
+export function ForgetTrack(arg1:string):Promise<void>;
+
 export function WriteFile(arg1:string,arg2:string):Promise<void>;

--- a/antra-wails/frontend/wailsjs/go/main/App.d.ts
+++ b/antra-wails/frontend/wailsjs/go/main/App.d.ts
@@ -12,6 +12,8 @@ export function CheckSourceHealth(arg1:string):Promise<string>;
 
 export function ClearHistory():Promise<void>;
 
+export function ForgetTrack(arg1:string):Promise<void>;
+
 export function GetArtistDiscography(arg1:string):Promise<string>;
 
 export function GetConfig():Promise<main.Config>;
@@ -43,7 +45,5 @@ export function SetSpotifyCookie(arg1:string):Promise<string>;
 export function SetSpotifyToken(arg1:string):Promise<string>;
 
 export function StartDownload(arg1:Array<string>):Promise<void>;
-
-export function ForgetTrack(arg1:string):Promise<void>;
 
 export function WriteFile(arg1:string,arg2:string):Promise<void>;

--- a/antra-wails/frontend/wailsjs/go/main/App.js
+++ b/antra-wails/frontend/wailsjs/go/main/App.js
@@ -86,6 +86,10 @@ export function StartDownload(arg1) {
   return window['go']['main']['App']['StartDownload'](arg1);
 }
 
+export function ForgetTrack(arg1) {
+  return window['go']['main']['App']['ForgetTrack'](arg1);
+}
+
 export function WriteFile(arg1, arg2) {
   return window['go']['main']['App']['WriteFile'](arg1, arg2);
 }

--- a/antra-wails/frontend/wailsjs/go/main/App.js
+++ b/antra-wails/frontend/wailsjs/go/main/App.js
@@ -22,6 +22,10 @@ export function ClearHistory() {
   return window['go']['main']['App']['ClearHistory']();
 }
 
+export function ForgetTrack(arg1) {
+  return window['go']['main']['App']['ForgetTrack'](arg1);
+}
+
 export function GetArtistDiscography(arg1) {
   return window['go']['main']['App']['GetArtistDiscography'](arg1);
 }
@@ -84,10 +88,6 @@ export function SetSpotifyToken(arg1) {
 
 export function StartDownload(arg1) {
   return window['go']['main']['App']['StartDownload'](arg1);
-}
-
-export function ForgetTrack(arg1) {
-  return window['go']['main']['App']['ForgetTrack'](arg1);
 }
 
 export function WriteFile(arg1, arg2) {

--- a/antra-wails/frontend/wailsjs/go/models.ts
+++ b/antra-wails/frontend/wailsjs/go/models.ts
@@ -1,5 +1,5 @@
 export namespace main {
-
+	
 	export class Config {
 	    download_path: string;
 	    soulseek_enabled: boolean;
@@ -13,11 +13,11 @@ export namespace main {
 	    prefer_explicit?: boolean;
 	    folder_structure?: string;
 	    filename_format?: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Config(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.download_path = source["download_path"];
@@ -39,11 +39,11 @@ export namespace main {
 	    artist: string;
 	    file_path?: string;
 	    status: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new HistoryTrack(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.title = source["title"];
@@ -64,11 +64,11 @@ export namespace main {
 	    error?: string;
 	    sources: Record<string, number>;
 	    tracks?: HistoryTrack[];
-
+	
 	    static createFrom(source: any = {}) {
 	        return new HistoryItem(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.date = source["date"];
@@ -81,8 +81,27 @@ export namespace main {
 	        this.skipped = source["skipped"];
 	        this.error = source["error"];
 	        this.sources = source["sources"];
-	        this.tracks = source["tracks"];
+	        this.tracks = this.convertValues(source["tracks"], HistoryTrack);
 	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
 
 }
+

--- a/antra-wails/frontend/wailsjs/go/models.ts
+++ b/antra-wails/frontend/wailsjs/go/models.ts
@@ -1,5 +1,5 @@
 export namespace main {
-	
+
 	export class Config {
 	    download_path: string;
 	    soulseek_enabled: boolean;
@@ -13,11 +13,11 @@ export namespace main {
 	    prefer_explicit?: boolean;
 	    folder_structure?: string;
 	    filename_format?: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new Config(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.download_path = source["download_path"];
@@ -34,6 +34,24 @@ export namespace main {
 	        this.filename_format = source["filename_format"];
 	    }
 	}
+	export class HistoryTrack {
+	    title: string;
+	    artist: string;
+	    file_path?: string;
+	    status: string;
+
+	    static createFrom(source: any = {}) {
+	        return new HistoryTrack(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.title = source["title"];
+	        this.artist = source["artist"];
+	        this.file_path = source["file_path"];
+	        this.status = source["status"];
+	    }
+	}
 	export class HistoryItem {
 	    date: string;
 	    url: string;
@@ -45,11 +63,12 @@ export namespace main {
 	    skipped: number;
 	    error?: string;
 	    sources: Record<string, number>;
-	
+	    tracks?: HistoryTrack[];
+
 	    static createFrom(source: any = {}) {
 	        return new HistoryItem(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.date = source["date"];
@@ -62,8 +81,8 @@ export namespace main {
 	        this.skipped = source["skipped"];
 	        this.error = source["error"];
 	        this.sources = source["sources"];
+	        this.tracks = source["tracks"];
 	    }
 	}
 
 }
-

--- a/antra/json_cli.py
+++ b/antra/json_cli.py
@@ -566,6 +566,15 @@ def main():
                 "date": datetime.now().isoformat(),
                 "total_mb": round(_total_bytes / (1024 * 1024), 1),
                 "elapsed_seconds": round(_elapsed),
+                "tracks": [
+                    {
+                        "title": r.track.title,
+                        "artist": r.track.artist_string,
+                        "file_path": r.file_path or "",
+                        "status": r.status.name,
+                    }
+                    for r in results
+                ],
             }
 
             for r in results:
@@ -596,6 +605,7 @@ def main():
                 "date": datetime.now().isoformat(),
                 "total_mb": 0,
                 "elapsed_seconds": round(_elapsed),
+                "tracks": [],
             }
             print(json.dumps(summary), flush=True)
 


### PR DESCRIPTION
<img width="451" height="407" alt="Screenshot 2026-04-22 at 9 00 31 PM" src="https://github.com/user-attachments/assets/4ce61936-c65f-42f6-9765-2e0fb2cf7a41" />

Adds new functionality to the Antra app that allows for single song deletion. This was crafted as a solution when Antra would occasionally identify the incorrect version of the song to download. When this happened, the same song could no longer be queued because it would automatically resolve to "Already in library".

By clicking on the single song delete:
- The audio file for the download is removed from the user's machine from wherever the app is pointing to
- The app re-enables the ability to download the track a second time, which was not possible before
